### PR TITLE
2023.11.07 RIP https://statsapi.web.nhl.com/api/v1 - update to use the new NHL Edge API as a base endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // IMPORTANT: Be sure to select the correct path to the Python interpreter (e.g. "./apps/nhl-shot-chart-fastapi/.venv/bin/python") for the Python Debug Console to work
+      "name": "Python: NHL shot chart",
+      "cwd": "${workspaceFolder}/apps/nhl-shot-chart-fastapi",
+      "type": "python",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": ["main:app"],
+      "jinja": true,
+      "justMyCode": true
+    }
+  ]
+}

--- a/apps/nhl-shot-chart-fastapi/lib/nhl/nhl_shot_chart.py
+++ b/apps/nhl-shot-chart-fastapi/lib/nhl/nhl_shot_chart.py
@@ -43,8 +43,11 @@ OUTPUT_SHOT_CHART_DIRECTORY_AND_FILENAME_PREFIX = (
 # Date and time
 LOCAL_DATE_TIME_FORMAT_STRING = "YYYY-MM-DD h:mm A z"  # '2023-01-19 7:00 PM PST'
 
-# NHL API
-NHL_API_BASE_URL = "https://statsapi.web.nhl.com/api/v1"
+# NHL Edge API
+NHL_API_BASE_URL = "https://api-web.nhle.com/v1"
+# TODO: Add support for an example NHL Edge API landing route - https://api-web.nhle.com/v1/gamecenter/2023020185/landing
+# TODO: Add support for an example NHL Edge API box score route - https://api-web.nhle.com/v1/gamecenter/2023020185/boxscore
+# TODO: Add support for an example NHL Edge API play-by-play route - https://api-web.nhle.com/v1/gamecenter/2023020185/play-by-play
 NHL_API_DATE_TIME_FORMAT_STRING = "%Y-%m-%dT%H:%M:%S%z"  # '2022-09-27T02:00:00Z'
 
 def convertToLocalDateTimeString(dateTimeString, timezone):
@@ -432,9 +435,9 @@ def generate_shot_chart_for_game(gameId, timezone):
 
 # Load live data for a specific game ID from the NHL API
 def load_live_data_for_game(gameId):
-    # https://statsapi.web.nhl.com/api/v1/game/2022020728/feed/live
+    # https://api-web.nhle.com/v1/gamecenter/2023020185/play-by-play
     NHL_API_LIVE_GAME_DATA_URL = (
-        NHL_API_BASE_URL + "/game/" + str(gameId) + "/feed/live"
+        NHL_API_BASE_URL + "/gamecenter/" + str(gameId) + "/play-by-play"
     )
     live_data = requests.get(NHL_API_LIVE_GAME_DATA_URL).json()
     return live_data


### PR DESCRIPTION
The NHL shot chart must be rewritten to accommodate the new endpoints from the NHL Edge API.

For the time being, game and shot chart data will not be available to be displayed.